### PR TITLE
Validate tibble after construction

### DIFF
--- a/R/tibblify.R
+++ b/R/tibblify.R
@@ -94,6 +94,8 @@ tibblify_impl <- function(recordlist, col_specs, keep_spec, names_to = NULL) {
     nrow = length(recordlist)
   )
 
+  tibble::validate_tibble(result)
+
   if (is_true(keep_spec)) {
     col_specs$cols <- collectors
 


### PR DESCRIPTION
to avoid segmentation faults.